### PR TITLE
Make sure yesterday is not used as today's match list, fixes #3

### DIFF
--- a/private/classes/SimpleInfoscreen/Cache.php
+++ b/private/classes/SimpleInfoscreen/Cache.php
@@ -26,7 +26,7 @@ THE SOFTWARE.
 /**
  * A class that lets you manipulate a cache file.
  * @author Thorben Werner Sjøstrøm Dahl <thorben@sjostrom.no>
- * @copyright Thorben Werner Sjøstrøm Dahl 2015
+ * @copyright Thorben Werner Sjøstrøm Dahl 2016
  * @license http://opensource.org/licenses/MIT The MIT License
  * @package tobinus\SimpleInfoscreen
  */
@@ -304,7 +304,7 @@ class Cache
         if (!empty($this->modificationTime) && !$reload) {
             return $this->modificationTime;
         } else if ($this->exists()) {
-            $this->modificationTime = filemtime($this->filepath);
+            $this->modificationTime = intval(filemtime($this->filepath));
             return $this->modificationTime;
         } else {
             throw new CacheDoesNotExist('Cannot get modification time when the cache file does not exist');

--- a/www/banedagbok.php
+++ b/www/banedagbok.php
@@ -26,9 +26,8 @@ THE SOFTWARE.
  * Show what matches will be played today (or any given day), by parsing a webpage
  * from handball.no.
  *
- * Limitation: Only one weekday can be in use
  * @author Thorben Dahl <thorben@sjostrom.no>
- * @copyright Thorben Dahl 2015
+ * @copyright Thorben Dahl 2016
  * @license The MIT License (MIT)
  * @package tobinus\SimpleInfoscreen
  */
@@ -69,11 +68,11 @@ try {
     // Perform an additional check on the cache validity
     // The cache is invalid if the resulting date from new DateTime() is different now than it was when the cache was created
     // What was the evaluated date back when the cache was created?
-    $cacheTime = "@" . $cacheFile->getModificationTime();  // get cache creation time
+    $cacheTime = "@" . ($cacheFile->getModificationTime() - 15);  // get cache creation time, subtract 15 just to be sure we're not using an old cache
     $oldMatchDate = new DateTime($cacheTime);  // start with the cache time
     $oldMatchDate->modify($matchDateString)->modify("midnight");  // apply the match date to the cache date, and set to midnight
     // Is there a difference?
-    if ($days = $matchDate->diff($oldMatchDate, true)->days) {
+    if ($matchDate->diff($oldMatchDate, true)->h) {
         // Yes
         throw new StaleCache();
     }


### PR DESCRIPTION
I don't really know what goes wrong, but with this commit,
the cache must have been made 15 seconds after midnight.
Hopefully that should avoid situations in which the date was
calculated before midnight, but the cache file was created
right after midnight (busting the assumption that the cache
file's date is the date it was generated on).

Hours are used when calculating the difference, that might
make a difference but I don't know.
